### PR TITLE
Simplified T/F literals by removing unicode characters due to issue with unicode characters in identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ From [https://en.wikipedia.org/wiki/List_of_logic_symbols](https://en.wikipedia.
 - (8) Equivalence (IF AND ONLY IF)
   - `↔`, `<->`, `==`, `⇔`, `≡`
 - (9) Tautology (True)
-  - `T`, `1`, `⊤`, `■`
+  - `T`, `1`
 - (9) Contradiction (False)
-  - `F`, `0`, `⊥`, `□`
+  - `F`, `0`
 - (10) Atomic Propositions (Variables)
   - Any valid variable name. (To be defined)
 

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -117,8 +117,7 @@ impl<'a> Lexer<'a> {
     }
 
     fn is_truthvalue_or_identifier_first_char(ch: char) -> bool {
-        Self::is_identifier_first_char(ch)
-            || matches!(ch, 'T' | 'F' | '1' | '0')
+        Self::is_identifier_first_char(ch) || matches!(ch, 'T' | 'F' | '1' | '0')
     }
 
     fn is_identifier_first_char(ch: char) -> bool {
@@ -270,7 +269,8 @@ mod tests {
 
     #[test]
     fn token_stream_parsing() {
-        let source = r#"A ab _a _0_a ( ) := : ¬ ~ ! && ∧ & . || ∨ | ⊕ ⊻ ^ -> → ⇒ ⊃ == <-> ↔ ⇔ ≡ T F 1 0"#;
+        let source =
+            r#"A ab _a _0_a ( ) := : ¬ ~ ! && ∧ & . || ∨ | ⊕ ⊻ ^ -> → ⇒ ⊃ == <-> ↔ ⇔ ≡ T F 1 0"#;
         let token_stream = TokenStream::parse(source).unwrap();
 
         let tokens = [

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -118,7 +118,7 @@ impl<'a> Lexer<'a> {
 
     fn is_truthvalue_or_identifier_first_char(ch: char) -> bool {
         Self::is_identifier_first_char(ch)
-            || matches!(ch, 'T' | 'F' | '1' | '0' | '⊤' | '⊥' | '■' | '□')
+            || matches!(ch, 'T' | 'F' | '1' | '0')
     }
 
     fn is_identifier_first_char(ch: char) -> bool {
@@ -154,10 +154,6 @@ impl<'a> Lexer<'a> {
                 "F" => TokenKind::TruthValue(false),
                 "1" => TokenKind::TruthValue(true),
                 "0" => TokenKind::TruthValue(false),
-                "⊤" => TokenKind::TruthValue(true),
-                "⊥" => TokenKind::TruthValue(false),
-                "■" => TokenKind::TruthValue(true),
-                "□" => TokenKind::TruthValue(false),
                 _ => TokenKind::Identifier(identifier),
             })
         }
@@ -274,7 +270,7 @@ mod tests {
 
     #[test]
     fn token_stream_parsing() {
-        let source = r#"A ab _a _0_a ( ) := : ¬ ~ ! && ∧ & . || ∨ | ⊕ ⊻ ^ -> → ⇒ ⊃ == <-> ↔ ⇔ ≡"#;
+        let source = r#"A ab _a _0_a ( ) := : ¬ ~ ! && ∧ & . || ∨ | ⊕ ⊻ ^ -> → ⇒ ⊃ == <-> ↔ ⇔ ≡ T F 1 0"#;
         let token_stream = TokenStream::parse(source).unwrap();
 
         let tokens = [
@@ -308,6 +304,10 @@ mod tests {
             TokenKind::BinaryOperator(BinaryOperator::Equivalence("↔")),
             TokenKind::BinaryOperator(BinaryOperator::Equivalence("⇔")),
             TokenKind::BinaryOperator(BinaryOperator::Equivalence("≡")),
+            TokenKind::TruthValue(true),
+            TokenKind::TruthValue(false),
+            TokenKind::TruthValue(true),
+            TokenKind::TruthValue(false),
         ];
 
         for (i, token) in token_stream.tokens.into_iter().enumerate() {


### PR DESCRIPTION
Solves issue that led to a halting problem when the is_identifier function could not consume the unicode characters for T/F.